### PR TITLE
Add ability to disable jsdoc

### DIFF
--- a/lib/node-configurator.js
+++ b/lib/node-configurator.js
@@ -88,25 +88,27 @@ exports.configure = function (config, options) {
         ]);
 
         // JsDoc techs
-        if (options.jsdocParser === 'jsd') {
-            nodeConfig.addTechs([
-                [jsdoc, { sourceSuffixes: options.jsSuffixes }],
-                [jsdocToMd],
-                [htmlFromMd, {
-                    target: '?.jsdoc.html',
-                    source: '?.jsdoc.md'
-                }]
-            ]);
+        if (options.jsdoc) {
+            if (options.jsdoc.parser === 'jsd') {
+                nodeConfig.addTechs([
+                    [jsdoc, { sourceSuffixes: options.jsdoc.suffixes }],
+                    [jsdocToMd],
+                    [htmlFromMd, {
+                        target: '?.jsdoc.html',
+                        source: '?.jsdoc.md'
+                    }]
+                ]);
 
-            nodeConfig.addTargets([
-                '?.jsdoc.json', '?.jsdoc.html'
-            ]);
-        } else if (options.jsdocParser === 'jsdoc3') {
-            nodeConfig.addTech([jsdoc3, { sourceSuffixes: options.jsSuffixes }]);
+                nodeConfig.addTargets([
+                    '?.jsdoc.json', '?.jsdoc.html'
+                ]);
+            } else if (options.jsdoc.parser === 'jsdoc3') {
+                nodeConfig.addTech([jsdoc3, { sourceSuffixes: options.jsdoc.suffixes }]);
 
-            nodeConfig.addTargets([
-                '?.jsdoc.json'
-            ]);
+                nodeConfig.addTargets([
+                    '?.jsdoc.json'
+                ]);
+            }
         }
 
         nodeConfig.addTargets([

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -6,6 +6,12 @@ var path = require('path'),
     configurator = require('./node-configurator'),
     deps = require('enb-bem/lib/deps/deps');
 
+function deprecateOption(option, replacement) {
+    console.warn('WARNING!');
+    console.warn('%s is deprecated.', option);
+    console.warn('use %s option instead', replacement);
+}
+
 module.exports = function (helper, exampleTaskName, exampleChannel) {
     return {
         configure: function (options) {
@@ -13,10 +19,18 @@ module.exports = function (helper, exampleTaskName, exampleChannel) {
             options.exampleSets || (options.exampleSets = []);
             options.docSuffixes || (options.docSuffixes = ['md', 'wiki']);
             options.docI18NSuffixes = options.langs ? buildI18NSuffixes(options.docSuffixes, options.langs) : [];
-            options.jsSuffixes || (options.jsSuffixes = ['js']);
-            options.jsdocParser || (options.jsdocParser = 'jsd');
-            options._examples = [];
 
+            if (options.jsdoc !== false) {
+                options.jsSuffixes && deprecateOption('jsSuffixes', 'jsdoc.suffixes');
+                options.jsdocParser && deprecateOption('jsdocParser', 'jsdoc.parser');
+
+                options.jsdoc || (options.jsdoc = {});
+
+                options.jsdoc.suffixes || (options.jsdoc.suffixes = (options.jsSuffixes || ['js']));
+                options.jsdoc.parser || (options.jsdoc.parser = (options.jsdocParser || ['jsd']));
+            }
+
+            options._examples = [];
             this._dependOnExamples(options);
             this._buildPseudoLevels(options);
             this._configureNodes(options);


### PR DESCRIPTION
Additionally,all jsdoc options are grouped in `jsdoc` section, old names are
deprecated. Use `jsdoc: false` to disable jsdoc.
