### PR TITLE
Fix jsdoc3 with new npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "main": "lib/index.js",
   "scripts": {
+    "postinstall": "npm i --no-save --global-style jsdoc-bem",
     "test": "npm run lint",
     "lint": "jshint . && jscs .",
     "build": "enb -d examples/silly make __magic__ set.docs && enb -d examples/langs make __magic__ set.docs && enb -d examples/examples make __magic__ set.docs && enb -d examples/jsdoc3 make __magic__ set.docs",


### PR DESCRIPTION
An ugly hack for jsdoc3 which needs `jsdoc-bem` in local `node_modules` folder (as new version of `npm` moves it to the top level `node_modules`).